### PR TITLE
helm fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,16 +52,13 @@ licenses: ## Verifies dependency licenses and requires GITHUB_TOKEN to be set
 	golicense hack/license-config.hcl karpenter
 
 apply: ## Deploy the controller into your ~/.kube/config cluster
-	helm template --include-crds karpenter charts/karpenter --namespace karpenter \
+	helm upgrade --install karpenter charts/karpenter --namespace karpenter \
 		$(HELM_OPTS) \
-		--set controller.image=ko://github.com/aws/karpenter/cmd/controller \
-		--set webhook.image=ko://github.com/aws/karpenter/cmd/webhook \
-		| $(WITH_GOFLAGS) ko apply -B -f -
+		--set controller.image=$(shell $(WITH_GOFLAGS) ko build -B github.com/aws/karpenter/cmd/controller) \
+		--set webhook.image=$(shell $(WITH_GOFLAGS) ko build -B github.com/aws/karpenter/cmd/webhook)
 
 delete: ## Delete the controller from your ~/.kube/config cluster
-	helm template karpenter charts/karpenter --namespace karpenter \
-		$(HELM_OPTS) \
-		| kubectl delete -f -
+	helm uninstall karpenter --namespace karpenter
 
 codegen: ## Generate code. Must be run if changes are made to ./pkg/apis/...
 	controller-gen \

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,10 @@ WITH_GOFLAGS = GOFLAGS=$(GOFLAGS)
 ## Extra helm options
 CLUSTER_NAME ?= $(shell kubectl config view --minify -o jsonpath='{.clusters[].name}' | rev | cut -d"/" -f1 | rev)
 CLUSTER_ENDPOINT ?= $(shell kubectl config view --minify -o jsonpath='{.clusters[].cluster.server}')
-HELM_OPTS ?= --set serviceAccount.annotations.eks\.amazonaws\.com/role-arn=${KARPENTER_IAM_ROLE_ARN} \
-      --set clusterName=${CLUSTER_NAME} \
+AWS_ACCOUNT_ID ?= $(shell aws sts get-caller-identity --output text | cut -d" " -f1)
+KARPENTER_IAM_ROLE_ARN ?= arn:aws:iam::${AWS_ACCOUNT_ID}:role/${CLUSTER_NAME}-karpenter
+HELM_OPTS ?= --set serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn=${KARPENTER_IAM_ROLE_ARN} \
+      		--set clusterName=${CLUSTER_NAME} \
 			--set clusterEndpoint=${CLUSTER_ENDPOINT} \
 			--set aws.defaultInstanceProfile=KarpenterNodeInstanceProfile-${CLUSTER_NAME}
 

--- a/charts/karpenter/templates/clusterrole.yaml
+++ b/charts/karpenter/templates/clusterrole.yaml
@@ -7,7 +7,7 @@ metadata:
   {{- with .Values.additionalAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
-  {{- }}
+  {{- end }}
 rules:
   - apiGroups: ["karpenter.sh"]
     resources: ["provisioners"]

--- a/charts/karpenter/templates/clusterrolebinding.yaml
+++ b/charts/karpenter/templates/clusterrolebinding.yaml
@@ -7,7 +7,7 @@ metadata:
   {{- with .Values.additionalAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
-  {{- }}
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/karpenter/templates/configmap-logging.yaml
+++ b/charts/karpenter/templates/configmap-logging.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: config-logging
+  name: karpenter-config-logging
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "karpenter.labels" . | nindent 4 }}
   {{- with .Values.additionalAnnotations }}
-  annotations:
+  annotations:-
     {{- toYaml . | nindent 4 }}
   {{- end }}
 data:

--- a/charts/karpenter/templates/configmap-logging.yaml
+++ b/charts/karpenter/templates/configmap-logging.yaml
@@ -2,12 +2,13 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: config-logging
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "karpenter.labels" . | nindent 4 }}
   {{- with .Values.additionalAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
-  {{- }}
+  {{- end }}
 data:
   # https://github.com/uber-go/zap/blob/aa3e73ec0896f8b066ddf668597a02f89628ee50/config.go
   zap-logger-config: |

--- a/charts/karpenter/templates/deployment.yaml
+++ b/charts/karpenter/templates/deployment.yaml
@@ -2,12 +2,13 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "karpenter.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "karpenter.labels" . | nindent 4 }}
   {{- with .Values.additionalAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
-  {{- }}
+  {{- end }}
 spec:
   replicas: {{ .Values.replicas }}
   {{- with .Values.strategy }}

--- a/charts/karpenter/templates/deployment.yaml
+++ b/charts/karpenter/templates/deployment.yaml
@@ -61,6 +61,8 @@ spec:
               value: {{ .Values.clusterName }}
             - name: CLUSTER_ENDPOINT
               value: {{ .Values.clusterEndpoint }}
+            - name: KARPENTER_SERVICE
+              value: {{ include "karpenter.fullname" . }}
             - name: SYSTEM_NAMESPACE
               valueFrom:
                 fieldRef:
@@ -103,6 +105,8 @@ spec:
               value: {{ .Values.clusterName }}
             - name: CLUSTER_ENDPOINT
               value: {{ .Values.clusterEndpoint }}
+            - name: KARPENTER_SERVICE
+              value: {{ include "karpenter.fullname" . }}
             - name: SYSTEM_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/charts/karpenter/templates/role.yaml
+++ b/charts/karpenter/templates/role.yaml
@@ -2,12 +2,13 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "karpenter.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "karpenter.labels" . | nindent 4 }}
   {{- with .Values.additionalAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
-  {{- }}
+  {{- end }}
 rules:
   - apiGroups: [""]
     resources: ["configmaps"]
@@ -26,7 +27,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["secrets"]
-    resourceNames: ["karpenter-webhook-cert"]
+    resourceNames: ["karpenter-cert"]
     verbs: ["get", "list", "watch", "update"]
   - apiGroups: [""]
     resources: ["secrets"]

--- a/charts/karpenter/templates/rolebinding.yaml
+++ b/charts/karpenter/templates/rolebinding.yaml
@@ -2,12 +2,13 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "karpenter.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "karpenter.labels" . | nindent 4 }}
   {{- with .Values.additionalAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
-  {{- }}
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/karpenter/templates/secret-webhook-cert.yaml
+++ b/charts/karpenter/templates/secret-webhook-cert.yaml
@@ -1,11 +1,12 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "karpenter.fullname" . }}-webhook--cert
+  name: {{ include "karpenter.fullname" . }}-cert
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "karpenter.labels" . | nindent 4 }}
   {{- with .Values.additionalAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
-  {{- }}
+  {{- end }}
 data: {} # Injected by karpenter-webhook

--- a/charts/karpenter/templates/service.yaml
+++ b/charts/karpenter/templates/service.yaml
@@ -1,13 +1,14 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "karpenter.fullname" . }}
+  name: karpenter
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "karpenter.labels" . | nindent 4 }}
   {{- with .Values.additionalAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
-  {{- }}
+  {{- end }}
 spec:
   type: ClusterIP
   ports:

--- a/charts/karpenter/templates/service.yaml
+++ b/charts/karpenter/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: karpenter
+  name: {{ include "karpenter.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "karpenter.labels" . | nindent 4 }}

--- a/charts/karpenter/templates/serviceaccount.yaml
+++ b/charts/karpenter/templates/serviceaccount.yaml
@@ -3,13 +3,14 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "karpenter.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "karpenter.labels" . | nindent 4 }}
   {{- if or .Values.additionalAnnotations .Values.serviceAccount.annotations }}
   annotations:
   {{- with .Values.additionalAnnotations }}
     {{- toYaml . | nindent 4 }}
-  {{- }}
+  {{- end }}
   {{- with .Values.serviceAccount.annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/karpenter/templates/servicemonitor.yaml
+++ b/charts/karpenter/templates/servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "karpenter.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "karpenter.labels" . | nindent 4 }}
   {{- with .Values.serviceMonitor.additionalLabels }}
@@ -11,7 +12,7 @@ metadata:
   {{- with .Values.additionalAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
-  {{- }}
+  {{- end }}
 spec:
   namespaceSelector:
     matchNames:

--- a/charts/karpenter/templates/webhooks.yaml
+++ b/charts/karpenter/templates/webhooks.yaml
@@ -2,12 +2,13 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: defaulting.webhook.provisioners.karpenter.sh
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "karpenter.labels" . | nindent 4 }}
   {{- with .Values.additionalAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
-  {{- }}
+  {{- end }}
 webhooks:
   - name: defaulting.webhook.provisioners.karpenter.sh
     admissionReviewVersions: ["v1"]
@@ -33,6 +34,7 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.provisioners.karpenter.sh
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "karpenter.labels" . | nindent 4 }}
 webhooks:
@@ -61,6 +63,7 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.config.karpenter.sh
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "karpenter.labels" . | nindent 4 }}
 webhooks:

--- a/charts/karpenter/values.yaml
+++ b/charts/karpenter/values.yaml
@@ -70,6 +70,7 @@ affinity:
   nodeAffinity:
     requiredDuringSchedulingIgnoredDuringExecution:
       nodeSelectorTerms:
+      - matchExpressions:
         - key: karpenter.sh/provisioner-name
           operator: DoesNotExist
 

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -45,8 +45,8 @@ func main() {
 	config := knativeinjection.ParseAndGetRESTConfigOrDie()
 	ctx := webhook.WithOptions(knativeinjection.WithNamespaceScope(signals.NewContext(), system.Namespace()), webhook.Options{
 		Port:        opts.WebhookPort,
-		ServiceName: "karpenter-webhook",
-		SecretName:  "karpenter-webhook-cert",
+		ServiceName: "karpenter",
+		SecretName:  "karpenter-cert",
 	})
 
 	// Register the cloud provider to attach vendor specific validation logic.

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/aws/karpenter/pkg/apis"
 	"github.com/aws/karpenter/pkg/cloudprovider"
@@ -45,8 +46,8 @@ func main() {
 	config := knativeinjection.ParseAndGetRESTConfigOrDie()
 	ctx := webhook.WithOptions(knativeinjection.WithNamespaceScope(signals.NewContext(), system.Namespace()), webhook.Options{
 		Port:        opts.WebhookPort,
-		ServiceName: "karpenter",
-		SecretName:  "karpenter-cert",
+		ServiceName: opts.KarpenterService,
+		SecretName:  fmt.Sprintf("%s-cert", opts.KarpenterService),
 	})
 
 	// Register the cloud provider to attach vendor specific validation logic.

--- a/pkg/utils/options/options.go
+++ b/pkg/utils/options/options.go
@@ -34,6 +34,7 @@ func MustParse() Options {
 	opts := Options{}
 	flag.StringVar(&opts.ClusterName, "cluster-name", env.WithDefaultString("CLUSTER_NAME", ""), "The kubernetes cluster name for resource discovery")
 	flag.StringVar(&opts.ClusterEndpoint, "cluster-endpoint", env.WithDefaultString("CLUSTER_ENDPOINT", ""), "The external kubernetes cluster endpoint for new nodes to connect with")
+	flag.StringVar(&opts.KarpenterService, "karpenter-service", env.WithDefaultString("KARPENTER_SERVICE", ""), "The Karpenter Service name for the dynamic webhook certificate")
 	flag.IntVar(&opts.MetricsPort, "metrics-port", env.WithDefaultInt("METRICS_PORT", 8080), "The port the metric endpoint binds to for operating metrics about the controller itself")
 	flag.IntVar(&opts.HealthProbePort, "health-probe-port", env.WithDefaultInt("HEALTH_PROBE_PORT", 8081), "The port the health probe endpoint binds to for reporting controller health")
 	flag.IntVar(&opts.WebhookPort, "port", 8443, "The port the webhook endpoint binds to for validation and mutation of resources")
@@ -53,6 +54,7 @@ func MustParse() Options {
 type Options struct {
 	ClusterName               string
 	ClusterEndpoint           string
+	KarpenterService          string
 	MetricsPort               int
 	HealthProbePort           int
 	WebhookPort               int

--- a/website/content/en/preview/development-guide.md
+++ b/website/content/en/preview/development-guide.md
@@ -56,7 +56,7 @@ make battletest # More rigorous tests run in CI environment
 ### Verbose Logging
 
 ```bash
-kubectl patch configmap config-logging -n karpenter --patch '{"data":{"loglevel.controller":"debug"}}'
+kubectl patch configmap karpenter-config-logging -n karpenter --patch '{"data":{"loglevel.controller":"debug"}}'
 ```
 
 ### Debugging Metrics


### PR DESCRIPTION
I did some manual testing and found a few things. 

 - Added inferring of `KARPENTER_IAM_ROLE_ARN` in Makefile so that devs don't have to set that in an env var
 - Fixed HELM_OPTS serviceAccount annotations --set (needed an extra `\` for escaping `.`
 - There were a few missing `{{- end }}` 
 - Although namespace may not be required when using `helm install` or `helm upgrade --install` (didn't try that), but it is when using `helm template`, so when I originally tried `make apply`  which does a `helm template ... | ko apply`  it installed karpenter in the default namespace.
 - The webhook certificate was inferring `karpenter-webhook` for the domain so changed to just `karpenter`
 - There was a missing `- matchExpressions:` on the nodeAffinity in the values.yaml file. 